### PR TITLE
Camera fix for cheating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ riderModule.iml
 .idea/
 .vs/
 BuildCameraCHE.sln.DotSettings.user
+BuildCameraCHE.csproj

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ riderModule.iml
 .vs/
 BuildCameraCHE.sln.DotSettings.user
 BuildCameraCHE.csproj
+BuildCameraCHE.csproj

--- a/BuildCameraCHE.cs
+++ b/BuildCameraCHE.cs
@@ -89,6 +89,10 @@ public class Valheim_Build_CameraPlugin : BaseUnityPlugin
 
         distanceCanBuildFromWorkbench = config("General", "Distance Can Build From Workbench", 100f, "Distance from nearest workbench/stonecutter/etc. that you can build or repair. (Valheim default is 20)");
 
+        resourcePickupRange = config("General", "Resource Pickup Range", 10f, "Distance from which you can pick up resources on the ground while in build mode. (Valheim default is 2)");
+
+        blockAutoPickupInBuildMode = config("General", "Block Auto Pickup In Build Mode", Toggle.Off, "When enabled, prevents dropped items from being automatically picked up while build mode is active.");
+
         cameraRangeMultiplier = config("General", "Camera Range Multiplier", 1f, "Changes maximum range camera can move away from the build station. 1 means the build station's" + " range, 2 means twice the build station range, etc.");
 
         cameraMoveSpeedMultiplier = config("General", "Camera Move Speed Multiplier", 3f, "Multiplies the speed at which the build camera pans (i.e. moves around).");
@@ -153,6 +157,8 @@ public class Valheim_Build_CameraPlugin : BaseUnityPlugin
     private static ConfigEntry<Toggle> _serverConfigLocked = null!;
     internal static ConfigEntry<float> distanceCanBuildFromAvatar = null!;
     internal static ConfigEntry<float> distanceCanBuildFromWorkbench = null!;
+    internal static ConfigEntry<float> resourcePickupRange = null!;
+    internal static ConfigEntry<Toggle> blockAutoPickupInBuildMode = null!;
     internal static ConfigEntry<float> cameraRangeMultiplier = null!;
     internal static ConfigEntry<float> cameraMoveSpeedMultiplier = null!;
     internal static ConfigEntry<Toggle> moveWithRespectToWorld = null!;

--- a/BuildCameraCHE.cs
+++ b/BuildCameraCHE.cs
@@ -26,8 +26,9 @@ namespace Valheim_Build_Camera;
 public class Valheim_Build_CameraPlugin : BaseUnityPlugin
 {
     internal const string ModName = "BuildCameraCHE";
-    internal const string ModVersion = "1.2.10";
+    internal const string ModVersion = "1.2.11";
     internal const string Author = "Azumatt";
+    internal const float CameraGroundClearance = 0.5f;
     private const string ModGUID = Author + "." + ModName;
     private readonly Harmony _harmony = new(ModGUID);
     private static string ConfigFileName = ModGUID + ".cfg";
@@ -87,8 +88,6 @@ public class Valheim_Build_CameraPlugin : BaseUnityPlugin
         distanceCanBuildFromAvatar = config("General", "Distance Can Build From Avatar", 100f, "Distance from your avatar that you can build or repair. (Valheim default is 8)");
 
         distanceCanBuildFromWorkbench = config("General", "Distance Can Build From Workbench", 100f, "Distance from nearest workbench/stonecutter/etc. that you can build or repair. (Valheim default is 20)");
-
-        resourcePickupRange = config("General", "Resource Pickup Range", 10f, "Distance from which you can pick up resources on the ground while in build mode. (Valheim default is 2)");
 
         cameraRangeMultiplier = config("General", "Camera Range Multiplier", 1f, "Changes maximum range camera can move away from the build station. 1 means the build station's" + " range, 2 means twice the build station range, etc.");
 
@@ -154,7 +153,6 @@ public class Valheim_Build_CameraPlugin : BaseUnityPlugin
     private static ConfigEntry<Toggle> _serverConfigLocked = null!;
     internal static ConfigEntry<float> distanceCanBuildFromAvatar = null!;
     internal static ConfigEntry<float> distanceCanBuildFromWorkbench = null!;
-    internal static ConfigEntry<float> resourcePickupRange = null!;
     internal static ConfigEntry<float> cameraRangeMultiplier = null!;
     internal static ConfigEntry<float> cameraMoveSpeedMultiplier = null!;
     internal static ConfigEntry<Toggle> moveWithRespectToWorld = null!;

--- a/Patches.cs
+++ b/Patches.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using UnityEngine;
+using Valheim_Build_Camera.Compatibility.WardIsLove;
 
 namespace Valheim_Build_Camera
 {
@@ -169,7 +170,7 @@ namespace Valheim_Build_Camera
     }
 
     /// <summary>
-    /// Prevents dropped items from auto-collecting while the build camera is active.
+    /// Optionally prevents dropped items from auto-collecting while the build camera is active.
     /// </summary>
     /// <param name="__instance"></param>
     /// <param name="__runOriginal"></param>
@@ -178,7 +179,9 @@ namespace Valheim_Build_Camera
     {
         static void Prefix(Player __instance, ref bool __runOriginal)
         {
-            __runOriginal = !(Utils.IsLocalPlayer(__instance) && Utils.InBuildMode());
+            __runOriginal = Valheim_Build_CameraPlugin.blockAutoPickupInBuildMode.Value != Valheim_Build_CameraPlugin.Toggle.On
+                || !Utils.IsLocalPlayer(__instance)
+                || !Utils.InBuildMode();
         }
     }
 
@@ -214,6 +217,15 @@ namespace Valheim_Build_Camera
             if (Utils.InBuildMode())
             {
                 Utils.UpdateBuildCamera(dt, ref __instance);
+                if (WardIsLovePlugin.IsLoaded() && CustomCheck.CheckAccess(Player.m_localPlayer.GetPlayerID(), __instance.transform.position, flash: false))
+                {
+                    Utils.AutoPickup(dt, ref __instance);
+                }
+                else if (!WardIsLovePlugin.IsLoaded() && PrivateArea.CheckAccess(__instance.transform.position, flash: false, wardCheck: true))
+                {
+                    Utils.AutoPickup(dt, ref __instance);
+                }
+
                 __runOriginal = false;
             }
             else

--- a/Patches.cs
+++ b/Patches.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using UnityEngine;
-using Valheim_Build_Camera.Compatibility.WardIsLove;
 
 namespace Valheim_Build_Camera
 {
@@ -170,6 +169,20 @@ namespace Valheim_Build_Camera
     }
 
     /// <summary>
+    /// Prevents dropped items from auto-collecting while the build camera is active.
+    /// </summary>
+    /// <param name="__instance"></param>
+    /// <param name="__runOriginal"></param>
+    [HarmonyPatch(typeof(Player), nameof(Player.AutoPickup))]
+    static class Player_AutoPickup_Patch
+    {
+        static void Prefix(Player __instance, ref bool __runOriginal)
+        {
+            __runOriginal = !(Utils.IsLocalPlayer(__instance) && Utils.InBuildMode());
+        }
+    }
+
+    /// <summary>
     /// Stops the player's avatar from moving when in build mode.
     /// </summary>
     /// <param name="__result"></param>
@@ -201,15 +214,6 @@ namespace Valheim_Build_Camera
             if (Utils.InBuildMode())
             {
                 Utils.UpdateBuildCamera(dt, ref __instance);
-                if (WardIsLovePlugin.IsLoaded() && CustomCheck.CheckAccess(Player.m_localPlayer.GetPlayerID(), __instance.transform.position, flash: false))
-                {
-                    Utils.AutoPickup(dt, ref __instance);
-                }
-                else if (!WardIsLovePlugin.IsLoaded() && PrivateArea.CheckAccess(__instance.transform.position, flash: false, wardCheck: true))
-                {
-                    Utils.AutoPickup(dt, ref __instance);
-                }
-
                 __runOriginal = false;
             }
             else

--- a/Utils.cs
+++ b/Utils.cs
@@ -289,5 +289,51 @@ namespace Valheim_Build_Camera
             }
         }
 
+        public static void AutoPickup(float dt, ref GameCamera __instance)
+        {
+            if (Valheim_Build_CameraPlugin.blockAutoPickupInBuildMode.Value == Valheim_Build_CameraPlugin.Toggle.On)
+                return;
+            if (Player.m_localPlayer.IsTeleporting() || !Player.m_enableAutoPickup || Player.m_localPlayer == null)
+                return;
+            Vector3 b = __instance.transform.position + Vector3.up;
+            foreach (Collider collider in Physics.OverlapSphere(b, Valheim_Build_CameraPlugin.resourcePickupRange.Value, Player.m_localPlayer.m_autoPickupMask))
+            {
+                if (collider.attachedRigidbody)
+                {
+                    ItemDrop component = collider.attachedRigidbody.GetComponent<ItemDrop>();
+                    FloatingTerrainDummy floatingTerrainDummy = null;
+                    if (component == null && (floatingTerrainDummy = collider.attachedRigidbody.gameObject.GetComponent<FloatingTerrainDummy>()) && floatingTerrainDummy)
+                        component = floatingTerrainDummy.m_parent.gameObject.GetComponent<ItemDrop>();
+                    if (component != null && component.m_autoPickup && !Player.m_localPlayer.HaveUniqueKey(component.m_itemData.m_shared.m_name) && component.GetComponent<ZNetView>().IsValid())
+                    {
+                        if (!component.CanPickup())
+                            component.RequestOwn();
+                        else if (!component.InTar())
+                        {
+                            component.Load();
+                            if (Player.m_localPlayer.m_inventory.CanAddItem(component.m_itemData) && component.m_itemData.GetWeight() + (double)Player.m_localPlayer.m_inventory.GetTotalWeight() <= (double)Player.m_localPlayer.GetMaxCarryWeight())
+                            {
+                                float num = Vector3.Distance(component.transform.position, b);
+                                if (num <= (double)Valheim_Build_CameraPlugin.resourcePickupRange.Value)
+                                {
+                                    if (num < Valheim_Build_CameraPlugin.resourcePickupRange.Value)
+                                    {
+                                        Player.m_localPlayer.Pickup(component.gameObject);
+                                    }
+                                    else
+                                    {
+                                        Vector3 vector3 = Vector3.Normalize(b - component.transform.position) * 15f * dt;
+                                        component.transform.position += vector3;
+                                        if (floatingTerrainDummy)
+                                            floatingTerrainDummy.transform.position += vector3;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
     }
 }

--- a/Utils.cs
+++ b/Utils.cs
@@ -27,6 +27,9 @@ namespace Valheim_Build_Camera
         internal static void EnableBuildMode()
         {
             Valheim_Build_CameraPlugin.inBuildMode[Player.m_localPlayer] = true;
+            Player.m_localPlayer.m_hovering = null;
+            Player.m_localPlayer.m_hoveringCreature = null;
+            Player.m_localPlayer.m_hoveringPiece = null;
 
             // When entering build mode, we reset the view direction of the build
             // camera, so that it matches the player's current direction. Thus, when
@@ -161,10 +164,11 @@ namespace Valheim_Build_Camera
         {
             if (ZoneSystem.instance.GetGroundHeight(__instance.transform.position, out float height))
             {
-                if (__instance.transform.position.y < height)
+                float minimumHeight = height + Valheim_Build_CameraPlugin.CameraGroundClearance;
+                if (__instance.transform.position.y < minimumHeight)
                 {
                     Vector3 p = __instance.transform.position;
-                    p.y = height;
+                    p.y = minimumHeight;
                     __instance.transform.position = p;
                 }
             }
@@ -285,48 +289,5 @@ namespace Valheim_Build_Camera
             }
         }
 
-        public static void AutoPickup(float dt, ref GameCamera __instance)
-        {
-            if (Player.m_localPlayer.IsTeleporting() || !Player.m_enableAutoPickup || Player.m_localPlayer == null)
-                return;
-            Vector3 b = __instance.transform.position + Vector3.up;
-            foreach (Collider collider in Physics.OverlapSphere(b, Valheim_Build_CameraPlugin.resourcePickupRange.Value, Player.m_localPlayer.m_autoPickupMask))
-            {
-                if (collider.attachedRigidbody)
-                {
-                    ItemDrop component = collider.attachedRigidbody.GetComponent<ItemDrop>();
-                    FloatingTerrainDummy floatingTerrainDummy = null;
-                    if (component == null && (floatingTerrainDummy = collider.attachedRigidbody.gameObject.GetComponent<FloatingTerrainDummy>()) && floatingTerrainDummy)
-                        component = floatingTerrainDummy.m_parent.gameObject.GetComponent<ItemDrop>();
-                    if (component != null && component.m_autoPickup && !Player.m_localPlayer.HaveUniqueKey(component.m_itemData.m_shared.m_name) && component.GetComponent<ZNetView>().IsValid())
-                    {
-                        if (!component.CanPickup())
-                            component.RequestOwn();
-                        else if (!component.InTar())
-                        {
-                            component.Load();
-                            if (Player.m_localPlayer.m_inventory.CanAddItem(component.m_itemData) && component.m_itemData.GetWeight() + (double)Player.m_localPlayer.m_inventory.GetTotalWeight() <= (double)Player.m_localPlayer.GetMaxCarryWeight())
-                            {
-                                float num = Vector3.Distance(component.transform.position, b);
-                                if (num <= (double)Valheim_Build_CameraPlugin.resourcePickupRange.Value)
-                                {
-                                    if (num < Valheim_Build_CameraPlugin.resourcePickupRange.Value)
-                                    {
-                                        Player.m_localPlayer.Pickup(component.gameObject);
-                                    }
-                                    else
-                                    {
-                                        Vector3 vector3 = Vector3.Normalize(b - component.transform.position) * 15f * dt;
-                                        component.transform.position += vector3;
-                                        if (floatingTerrainDummy)
-                                            floatingTerrainDummy.transform.position += vector3;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
+ Prevent camera from going below ground, this stops clipping and people from being able to spy silver ore locations.
+ Added an global optional block for auto pickup, prevents using the camera to pick up objects at a distance.